### PR TITLE
Highlight with higher priority than treesitter.

### DIFF
--- a/lua/nvim-semantic-tokens.lua
+++ b/lua/nvim-semantic-tokens.lua
@@ -53,7 +53,13 @@ local function reset_cache()
 end
 
 local function highlight(buf, token, hl)
-  vim.highlight.range(buf, ns, hl, { token.line, token.start_char }, { token.line, token.start_char + token.length })
+  vim.api.nvim_buf_set_extmark(buf, ns, token.line, token.start_char, {
+    end_row = token.line,
+    end_col = token.start_char+token.length,
+    hl_group = hl,
+  -- Highlights from treesitter have prio 100, set prio for semantic tokens just above that
+    priority = 101
+  })
 end
 
 local function highlight_token(ctx, token)


### PR DESCRIPTION
Hey, I noticed that the default-priority for `vim.highlight.range` was changed in [this PR](https://github.com/neovim/neovim/pull/16963), which caused treesitters' highlights (prio 100) to override those set from semantic tokens.
IMO lsp should override treesitter when it comes to highlights, hence priority 101 (maybe make it configurable? not sure if that would have any benefit though).