### PR TITLE
Don't invalidate highlights on error or stale response

### DIFF
--- a/lua/nvim-semantic-tokens/semantic_tokens.lua
+++ b/lua/nvim-semantic-tokens/semantic_tokens.lua
@@ -58,9 +58,6 @@ function M.on_full(err, response, ctx, config)
   if not client then
     return
   end
-  if config and config.on_invalidate_range then
-    config.on_invalidate_range(ctx, 0, -1)
-  end
   -- if tick has changed our response is outdated!
   -- FIXME: this is should be done properly here and in the codelens implementation. Handlers should
   -- not be responsible of checking whether their responses are still valid.
@@ -71,6 +68,9 @@ function M.on_full(err, response, ctx, config)
     or last_tick[ctx.bufnr] ~= vim.api.nvim_buf_get_changedtick(ctx.bufnr)
   then
     return
+  end
+  if config and config.on_invalidate_range then
+    config.on_invalidate_range(ctx, 0, -1)
   end
   local legend = client.server_capabilities.semanticTokensProvider.legend
   local token_types = legend.tokenTypes


### PR DESCRIPTION
With rust_analyzer, if I add or remove multiple lines in quick succession, there are multiple in-flight token requests. The tick check fails for the first response, which leaves the buffer un-highlighted momentarily, but then the 'correct' response arrives, and highlighting is correct again.

Stale highlights shouldn't cause a problem, as LSP highlights should be strictly better than non-LSP ones 99% of the times.