### PR TITLE
update and improve info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Neovim is still required.
 
 ```lua
 require("nvim-semantic-tokens").setup {
-  preset = "default"
+  preset = "default",
   -- highlighters is a list of modules following the interface of nvim-semantic-tokens.table-highlighter or 
   -- function with the signature: highlight_token(ctx, token, highlight) where 
   --        ctx (as defined in :h lsp-handler)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use an autocommand for a filetype for which you have a language server set up th
 
 ```vim
 if &filetype == "cpp" || &filetype == "cuda" || &filetype == "c"
-  autocmd BufEnter,CursorHold,InsertLeave <buffer> lua require 'vim.lsp.buf'.semantic_tokens_full()
+  autocmd BufEnter,TextChanged <buffer> lua require 'vim.lsp.buf'.semantic_tokens_full()
 endif
 ```
 
@@ -38,7 +38,16 @@ or inside an `on_attach` call to a LSP client
 local on_attach = function(client, bufnr)
     local caps = client.server_capabilities
     if caps.semanticTokensProvider and caps.semanticTokensProvider.full then
-        vim.cmd [[autocmd BufEnter,CursorHold,InsertLeave <buffer> lua vim.lsp.buf.semantic_tokens_full()]]
+      local augroup = vim.api.nvim_create_augroup("SemanticTokens", {})
+      vim.api.nvim_create_autocmd("TextChanged", {
+        group = augroup,
+        buffer = bufnr,
+        callback = function()
+          vim.lsp.buf.semantic_tokens_full()
+        end,
+      })
+      -- fire it first time on load as well
+      vim.lsp.buf.semantic_tokens_full()
     end
     --...
 end

--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ end
 - rust-analyzer
 - sumneko-lua
 - pyright
+- tsserver
 - ...


### PR DESCRIPTION
We can just use `TextChanged` event - it fires ONLY when we change anything in
buffer and that's the only case when we need to refresh tokens. `BufEnter` does
not make sense for an attach function case cuz on_attach IS somewhat `BufEnter`.

Also better to use new lua api if we're required to run nightly anyways.

And `tsserver` supports them I checked 🙂

Thanks for the plugin and for the incoming PR, it's the only vscode feature I still envied for. Neovim becomes better than I have ever imagined 👽
