### PR TITLE
chore: add semantic token decorator (lsp 3.17.0)

### DIFF
--- a/lua/nvim-semantic-tokens.lua
+++ b/lua/nvim-semantic-tokens.lua
@@ -83,6 +83,7 @@ function M.extend_capabilities(caps)
       "number",
       "regexp",
       "operator",
+      "decorator",
     },
     tokenModifiers = {
       "declaration",

--- a/lua/nvim-semantic-tokens/presets/default.lua
+++ b/lua/nvim-semantic-tokens/presets/default.lua
@@ -23,6 +23,7 @@ semantic_tokens.token_map = {
   number = "LspNumber",
   regexp = "LspRegexp",
   operator = "LspOperator",
+  decorator = "LspDecorator",
 }
 
 semantic_tokens.modifiers_map = {


### PR DESCRIPTION
@decorator is missing

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/