### PR TITLE
Check if the buffer is loaded before calling nvim_buf_get_changedtick

### DIFF
--- a/lua/nvim-semantic-tokens/semantic_tokens.lua
+++ b/lua/nvim-semantic-tokens/semantic_tokens.lua
@@ -56,7 +56,7 @@ end
 function M.on_full(err, response, ctx, config)
   active_requests[ctx.bufnr] = false
   local client = vim.lsp.get_client_by_id(ctx.client_id)
-  if not client then
+  if not client or not vim.api.nvim_buf_is_loaded(ctx.bufnr) then
     return
   end
   -- if tick has changed our response is outdated!


### PR DESCRIPTION
This PR fixes the following error, I'm getting it after calling `bwipeout` on a buffer

```
Error executing vim.schedule lua callback: ...ntic-tokens/lua/nvim-semantic-tokens/semantic_tokens.lua:69: Invalid buffer id: 5
stack traceback:
        [C]: in function 'nvim_buf_get_changedtick'
        ...ntic-tokens/lua/nvim-semantic-tokens/semantic_tokens.lua:69: in function 'handler'
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1390: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
Error detected while processing FocusGained Autocommands for "*":
E11: Invalid in command-line window; <CR> executes, CTRL-C quits: checktime
```
